### PR TITLE
Add Support for Django 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ MANIFEST
 build
 dist
 .idea
+venv

--- a/athumb/templatetags/thumbnail.py
+++ b/athumb/templatetags/thumbnail.py
@@ -10,10 +10,8 @@ Mikko Hellsing, Chris Beaven.
 Modifications and new ideas, Copyright (c) 2010, DUO Interactive, LLC.
 """
 import re
-import math
 from django.template import Library, Node, Variable, VariableDoesNotExist, TemplateSyntaxError
 from django.conf import settings
-from django.utils.encoding import force_text
 
 register = Library()
 


### PR DESCRIPTION
This adds support for Django 4 by removing an unused import of `force_text`. I also removed the `math` import (also unused) and added venv to the .gitignore.